### PR TITLE
Add parallel processing to Invoke-DBPoolContainerActions

### DIFF
--- a/Datto-DBPool_API/Public/Containers/Containers/New-DBPoolContainer.ps1
+++ b/Datto-DBPool_API/Public/Containers/Containers/New-DBPoolContainer.ps1
@@ -4,23 +4,21 @@ function New-DBPoolContainer {
         The New-DBPoolContainer function is used to create a new container from the DBPool API.
 
     .DESCRIPTION
-        The New-DBPoolContainer function is used to create a new container in the DBPool based on the provided container name and parent container information.
-
-        This requires a container name and at least one at least one of the parent* fields must be specified.
-        If multiple parent fields are specified, both conditions will have to match a parent for it to be selected.
-
-    .PARAMETER ContainerName
-        The name for the container to create.
+        This function creates a new container in the DBPool based on the provided container name and parent container information.
+        The ContainerName parameter is mandatory, and at least one of the parent parameters (ParentId, ParentName, or ParentDefaultDatabase) must be specified.
     
+    .PARAMETER ContainerName
+        The name for the new container.
+
     .PARAMETER ParentId
         The ID of the parent container to clone.
-    
+
     .PARAMETER ParentName
         The name of the parent container to clone.
-    
+
     .PARAMETER ParentDefaultDatabase
         The default database of the parent container to clone.
-    
+
     .EXAMPLE
         New-DBPoolContainer -ContainerName 'MyNewContainer' -ParentId 12345
 
@@ -69,9 +67,11 @@ function New-DBPoolContainer {
 
         $body['name'] = $ContainerName
 
-        # Check if at least one parent parameter is provided
+        # Check that at least one parent parameter is provided
+        # This is done rather than using parameter sets or mandatory parameters to allow for multiple parent parameters to be provided as API accepts multiple parent parameter inputs
+        # If multiple fields are specified, both conditions will have to match a parent for it to be selected.
         if (-not ($PSBoundParameters.ContainsKey('ParentId') -or $PSBoundParameters.ContainsKey('ParentName') -or $PSBoundParameters.ContainsKey('ParentDefaultDatabase'))) {
-            throw "At least one parent parameter must be provided."
+            Write-Error "At least one parent parameter (ParentId, ParentName, or ParentDefaultDatabase) must be provided." -ErrorAction Stop
         }
 
         # Insert specified parent parameters into the request body

--- a/Datto-DBPool_API/Public/Containers/Containers/actions/Invoke-DBPoolContainerAction.ps1
+++ b/Datto-DBPool_API/Public/Containers/Containers/actions/Invoke-DBPoolContainerAction.ps1
@@ -12,6 +12,12 @@ function Invoke-DBPoolContainerAction {
     .PARAMETER Action
         The action to perform on the container. Valid actions are: refresh, schema-merge, start, restart, or stop.
 
+        Start, Stop, and Restart are all considered minor actions and will not require a confirmation prompt.
+        Refresh and Schema-Merge are considered major actions and will require a confirmation prompt.
+
+    .PARAMETER Force
+        Skip the confirmation prompt for major actions, such as 'Refresh' and 'Schema-Merge'.
+
     .EXAMPLE
         Invoke-DBPoolContainerAction -Id '12345' -Action 'restart'
 
@@ -63,26 +69,32 @@ function Invoke-DBPoolContainerAction {
 
         $method = 'POST'
 
+        # Write warning when using deprecated 'schema-merge' action, otherwise set confirmation prompt for 'major' actions
         if ($Action -eq 'schema-merge') {
             Write-Warning 'The action [ schema-merge ] is deprecated! Use the [ refresh ] action as the supported way to update a container.'
+            $ConfirmPreference = 'Medium'
+        } elseif ($Action -eq 'refresh' -and -not $Force) {
             $ConfirmPreference = 'Medium'
         }
 
         $moduleName = $MyInvocation.MyCommand.Module.Name
         if ([string]::IsNullOrEmpty($moduleName)) {
-            throw 'The function is not part of a module or the module name is not available.'
+            Write-Error 'The function is not loaded as part of a module or the module name is not available.' -ErrorAction Stop
         }
         $modulePath = (Get-Module -Name $moduleName).Path
 
         $runspacePool = [runspacefactory]::CreateRunspacePool(1, [Environment]::ProcessorCount - 1)
         $runspacePool.Open()
         $runspaces = [System.Collections.ArrayList]::new()
+
     }
 
     process {
+
         foreach ($n in $Id) {
             $requestPath = "/api/v2/containers/$n/actions/$Action"
 
+             # Try to get the container name to output for the ID when using the Verbose preference
             if ($VerbosePreference -eq 'Continue') {
                 try {
                     $containerName = (Get-DBPoolContainer -Id $n -ErrorAction stop).name
@@ -102,18 +114,23 @@ function Invoke-DBPoolContainerAction {
                         Add-DBPoolBaseURI -base_uri $baseUri
                         Add-DBPoolApiKey -apiKey $apiKey
 
+                        $warnings = [System.Collections.ArrayList]::new()
+                        $warningPreference = 'Continue'
+
                         try {
-                            $requestResponse = Invoke-DBPoolRequest -method $method -resource_Uri $requestPath -ErrorAction Stop
+                            $requestResponse = Invoke-DBPoolRequest -method $method -resource_Uri $requestPath -WarningVariable warnings -ErrorAction Stop
                             return [pscustomobject]@{
                                 Success    = $true
                                 StatusCode = $requestResponse.StatusCode
                                 Content    = $requestResponse.Content
+                                Warnings   = $warnings
                             }
                         } catch {
                             return [pscustomobject]@{
                                 Success      = $false
                                 ErrorMessage = $_.Exception.Message
                                 ErrorDetails = $_.Exception.ToString()
+                                Warnings     = $warnings
                             }
                         }
                     }).AddArgument($method).AddArgument($requestPath).AddArgument($modulePath).AddArgument($Global:DBPool_Base_URI).AddArgument($Global:DBPool_ApiKey)
@@ -128,17 +145,26 @@ function Invoke-DBPoolContainerAction {
             foreach ($runspace in $runspaces.ToArray()) {
                 if ($runspace.Handle.IsCompleted) {
                     $results = $runspace.Pipe.EndInvoke($runspace.Handle)
-                    
+            
                     foreach ($result in $results) {
-                        if ($result.Success) {
-                            $statusCode = $result.StatusCode
-                            if ($statusCode -eq 204) {
-                                Write-Output "Success: Invoking Action [ $Action ] on Container [ ID: $($runspace.ContainerId) ]."
-                            } else {
-                                Write-Error "Failed: Status $statusCode. Response: $($result.Content)"
+                        switch ($true) {
+                            { $result.Success } {
+                                $statusCode = $result.StatusCode
+                                if ($statusCode -eq 204) {
+                                    Write-Output "Success: Invoking Action [ $Action ] on Container [ ID: $($runspace.ContainerId) ]."
+                                } else {
+                                    Write-Error "Failed: Status $statusCode. Response: $($result.Content)"
+                                }
+                                break
                             }
-                        } else {
-                            Write-Error "Container [ID: $($runspace.ContainerId)]: $($result.ErrorMessage)"
+                            { $result.Warnings.Count -gt 0 } {
+                                foreach ($warning in $result.Warnings) {
+                                    Write-Warning "Container [ID: $($runspace.ContainerId)]: $warning"
+                                }
+                            }
+                            { !$result.Success } {
+                                Write-Error "Container [ID: $($runspace.ContainerId)]: $($result.ErrorMessage)"
+                            }
                         }
                     }
 
@@ -149,11 +175,13 @@ function Invoke-DBPoolContainerAction {
 
             Start-Sleep -Milliseconds 500
         }
+
     }
 
     end {
-        # Ensure the runspace pool is closed and disposed
+
         $runspacePool.Close()
         $runspacePool.Dispose()
+
     }
 }


### PR DESCRIPTION
Added concurrency via PowerShell Runspaces to Invoke-DBPoolContainerActions for long running tasks such as 'Refresh' which improves parallel processing of API requests and receiving response